### PR TITLE
Fix quality score calculations

### DIFF
--- a/lib/ref_calc.py
+++ b/lib/ref_calc.py
@@ -201,6 +201,7 @@ def refCalc(file_item):
                 # If no reads have mapped to the site, assign score -2 and skip everything else.
                 else:
                     ref, log_gls = glCalc(line, globs['genotypes'], globs['probs'], globs['mapq'], globs['haploid']);
+                    calc_rq_flag = True;
                 # Otherwise call the genotype likelihood function.
 
             else:


### PR DESCRIPTION
When processing a pileup file, if a site has no data, then all subsequent sites will receive a quality score of -2.

In the refCalc function, if a site has no data the flag calc_rq_flag is set to False. However, this flag is never reset, so all following sites will have a quality score of -2.